### PR TITLE
Update facturx.py

### DIFF
--- a/facturx/facturx.py
+++ b/facturx/facturx.py
@@ -649,7 +649,6 @@ def _facturx_update_metadata_add_attachment(
         flavor, level, orderx_type, pdf_metadata)
     metadata_file_entry = DecodedStreamObject()
     metadata_file_entry.setData(metadata_xml_bytes)
-    metadata_file_entry = metadata_file_entry.flateEncode()
     metadata_file_entry.update({
         NameObject('/Subtype'): NameObject('/XML'),
         NameObject('/Type'): NameObject('/Metadata'),


### PR DESCRIPTION
In order to keep the PDF/A conformity when legally signing the PDF via Trustweaver, the metadata_file_entry = metadata_file_entry.flateEncode() line 652 had to be removed.